### PR TITLE
update path_traversal rule

### DIFF
--- a/nodejsscan/path_traversal.js
+++ b/nodejsscan/path_traversal.js
@@ -2,6 +2,9 @@ var http = require('http'),
     fileSystem = require('fs'),
     path = require('path');
 
+var config = require('../config');
+var Promise = require('bluebird');
+Promise.promisifyAll(fileSystem);
 
 var express = require('express');
 var app = express();
@@ -19,6 +22,19 @@ app.get('/', function (req, res) {
     fileSystem.readFile(foo + "bar");
     readStream.pipe(res);
 });
+
+app.get('/foo', function (req, res) {
+    // ruleid:generic_path_traversal
+    var date = req.query.date;
+    var fileName = config.dirName + '/' + date;
+    var downloadFileName = 'log_' + fileName + '.txt';
+
+    fs.readFileAsync(fileName)
+      .then(function(data) {
+        res.download(fileName, downloadFileName);
+      })
+})
+
 app.listen(8888);
 // do not match
 fileSystem.readFile(ddd);

--- a/nodejsscan/path_traversal.yaml
+++ b/nodejsscan/path_traversal.yaml
@@ -14,8 +14,12 @@ rules:
         - pattern-inside: |
             $ELEC = require('electron');
             ...
-      - pattern-inside: |
-          $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) { ... })
+      - pattern-either:
+        - pattern-inside: function ($REQ, $RES, ...) {...}
+        - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
+        - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
+        - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
+        - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
       - pattern-either:
           - pattern: |
               $X.createReadStream(..., <... $REQ.$QUERY.$VAR ...>, ...)
@@ -30,6 +34,10 @@ rules:
           - pattern: |
               $X.readFileSync(..., <... $REQ.$QUERY ...>, ...)
           - pattern: |
+              $X.readFileAsync(..., <... $REQ.$QUERY.$VAR ...>, ...)
+          - pattern: |
+              $X.readFileAsync(..., <... $REQ.$QUERY ...>, ...)
+          - pattern: |
               $INP = <... $REQ.$QUERY.$VAR ...>;
               ...
               $X.createReadStream(..., <... $INP ...>, ...);
@@ -53,6 +61,62 @@ rules:
               $INP = <... $REQ.$QUERY ...>;
               ...
               $X.readFileSync(..., <... $INP ...>, ...);
+          - pattern: |
+              $INP = <... $REQ.$QUERY.$VAR ...>;
+              ...
+              $X.readFileAsync(..., <... $INP ...>, ...);
+          - pattern: |
+              $INP = <... $REQ.$QUERY ...>;
+              ...
+              $X.readFileAsync(..., <... $INP ...>, ...);
+          - pattern: |
+              $Y = $REQ.$QUERY.$VAR;
+              ...
+              $INP = <... $Y ...>;
+              ...
+              $X.createReadStream(..., <... $INP ...>, ...);
+          - pattern: |
+              $Y = $REQ.$QUERY;
+              ...
+              $INP = <... $Y ...>;
+              ...
+              $X.createReadStream(..., <... $INP ...>, ...);
+          - pattern: |
+              $Y = $REQ.$QUERY.$VAR;
+              ...
+              $INP = <... $Y ...>;
+              ...
+              $X.readFile(..., <... $INP ...>, ...);
+          - pattern: |
+              $Y = $REQ.$QUERY;
+              ...
+              $INP = <... $Y ...>;
+              ...
+              $X.readFile(..., <... $INP ...>, ...);
+          - pattern: |
+              $Y = $REQ.$QUERY.$VAR;
+              ...
+              $INP = <... $Y ...>;
+              ...
+              $X.readFileSync(..., <... $INP ...>, ...);
+          - pattern: |
+              $Y = $REQ.$QUERY;
+              ...
+              $INP = <... $Y ...>;
+              ...
+              $X.readFileSync(..., <... $INP ...>, ...);
+          - pattern: |
+              $Y = $REQ.$QUERY.$VAR;
+              ...
+              $INP = <... $Y ...>;
+              ...
+              $X.readFileAsync(..., <... $INP ...>, ...);
+          - pattern: |
+              $Y = $REQ.$QUERY;
+              ...
+              $INP = <... $Y ...>;
+              ...
+              $X.readFileAsync(..., <... $INP ...>, ...);
     message: >-
       Untrusted user input in readFile()/readFileSync() can endup in Directory
       Traversal Attacks.


### PR DESCRIPTION
extended the rule to cover `bluebird` promises

```javascript
var Promise = require('bluebird');
var fs = require("fs");
Promise.promisifyAll(fs);

fs.readFileAsync("file.js", "utf8").then(...)
```